### PR TITLE
Add `--sync` option to write file on `textDocument/didSave`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -586,6 +586,7 @@ name = "lsp-ws-proxy"
 version = "0.2.0"
 dependencies = [
  "argh",
+ "async-fs",
  "async-io",
  "async-net",
  "async-process",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["command-line-utilities"]
 [dependencies]
 argh = "0.1"
 async-io = "1.0"
+async-fs = "1.2"
 async-net = "1.2"
 async-process = "1.0"
 async-tungstenite = "0.8"

--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Examples:
   lsp-ws-proxy -l 8888 -- langserver --stdio
 
 Options:
-  -v, --version     show version and exit
   -l, --listen      address or localhost's port to listen on (default: 9999)
   -t, --timeout     inactivity timeout in seconds
+  -s, --sync        write text document to disk on save
+  -v, --version     show version and exit
   --help            display usage information
 ```
 
@@ -30,5 +31,5 @@ Options:
 
 - [x] Proxy messages
 - [x] Inactivity timeout
+- [x] Synchronize files
 - [ ] Remap `DocumentUri`
-- [ ] Synchronize files

--- a/src/client.rs
+++ b/src/client.rs
@@ -1,0 +1,31 @@
+use std::str::FromStr;
+
+use async_tungstenite::tungstenite as ws;
+
+use crate::lsp;
+
+// Type to describe a message from the client conveniently.
+pub(crate) enum Message {
+    // Valid LSP message
+    Message(lsp::Message),
+    // Invalid JSON
+    Invalid(String),
+    // Close message
+    Close(Option<ws::protocol::CloseFrame<'static>>),
+}
+
+// Parse the message and ignore anything we don't care.
+pub(crate) async fn filter_map_ws_message(
+    wsm: Result<ws::Message, ws::Error>,
+) -> Option<Result<Message, ws::Error>> {
+    match wsm {
+        Ok(ws::Message::Text(text)) => match lsp::Message::from_str(&text) {
+            Ok(msg) => Some(Ok(Message::Message(msg))),
+            Err(_) => Some(Ok(Message::Invalid(text))),
+        },
+        Ok(ws::Message::Close(frame)) => Some(Ok(Message::Close(frame))),
+        // Ignore any other message types
+        Ok(_) => None,
+        Err(err) => Some(Err(err)),
+    }
+}

--- a/src/lsp/notification.rs
+++ b/src/lsp/notification.rs
@@ -3,6 +3,19 @@ use serde::{Deserialize, Serialize};
 // NOTE Not using `lsp_types::lsp_notification!` because rust-analyzer
 // doesn't seem to understand it well at the moment and shows `{unknown}`.
 
+// TODO Remove this when a new version of `lsp_types` is published with the fix.
+// https://github.com/gluon-lang/lsp-types/pull/178
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct DidSaveTextDocumentParams {
+    /// The document that was saved.
+    pub text_document: lsp_types::TextDocumentIdentifier,
+    /// Optional the content when saved. Depends on the includeText value
+    /// when the save notification was requested.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub text: Option<String>,
+}
+
 /// A [notification message].
 ///
 /// [notification message]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
@@ -66,9 +79,7 @@ pub(crate) enum Notification {
     // To Server
     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave
     #[serde(rename = "textDocument/didSave")]
-    DidSave {
-        params: lsp_types::DidSaveTextDocumentParams,
-    },
+    DidSave { params: DidSaveTextDocumentParams },
 
     // To Server
     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didClose


### PR DESCRIPTION
The client needs to include `text` field even when the server doesn't require it.
If this is a problem, we can introduce an extension and intercept it.