### PR TITLE
Remap relative DocumentUri

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -602,6 +602,7 @@ dependencies = [
  "serde",
  "serde_json",
  "smol",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,9 +569,9 @@ dependencies = [
 
 [[package]]
 name = "lsp-types"
-version = "0.80.0"
+version = "0.81.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4265e2715bdacbb4dad029fce525e420cd66dc0af24ff9cb996a8ab48ac92ef"
+checksum = "5e02724627e9ef8ba91f461ebc01d48aebbd13a4b7c9dc547a0a2890f53e2171"
 dependencies = [
  "base64",
  "bitflags",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 smol = "1.0"
 env_logger = "0.7"
+url = "2.1"
 
 [dev-dependencies]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ futures-io = "0.3"
 futures-util = "0.3"
 futures_codec = "0.4"
 log = "0.4"
-lsp-types = "0.80"
+lsp-types = "0.81"
 nom = { version = "5.1", default-features = false, features = ["std"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Single binary WebSocket proxy for Language Server.
 ```
 $ lsp-ws-proxy --help
 
-Usage: lsp-ws-proxy [-l <listen>] [-t <timeout>] [-s] [-v]
+Usage: lsp-ws-proxy [-l <listen>] [-t <timeout>] [-s] [-r] [-v]
 
 Start WebSocket proxy for the LSP Server.
 Anything after the option delimiter is used to start the server.
@@ -23,6 +23,7 @@ Options:
   -l, --listen      address or localhost's port to listen on (default: 9999)
   -t, --timeout     inactivity timeout in seconds
   -s, --sync        write text document to disk on save
+  -r, --remap       remap relative uri (source://)
   -v, --version     show version and exit
   --help            display usage information
 ```
@@ -32,4 +33,4 @@ Options:
 - [x] Proxy messages
 - [x] Inactivity timeout
 - [x] Synchronize files
-- [ ] Remap `DocumentUri`
+- [x] Remap relative `DocumentUri` (`source://`)

--- a/src/lsp/ext/mod.rs
+++ b/src/lsp/ext/mod.rs
@@ -1,0 +1,4 @@
+//! Nonstandard LSP features.
+mod relative_uri;
+
+pub(crate) use relative_uri::remap_relative_uri;

--- a/src/lsp/ext/relative_uri.rs
+++ b/src/lsp/ext/relative_uri.rs
@@ -1,0 +1,465 @@
+use std::collections::HashMap;
+
+use url::Url;
+
+use crate::lsp::{Message, Notification, Request, Response, ResponseResult};
+
+/// Remap URI relative to current directory (`source://`) to absolute URI (`file://`).  
+/// `source://` was chosen because it's used by [Metals Remote Language Server].
+///
+/// [Metals Remote Language Server]: https://scalameta.org/metals/docs/contributors/remote-language-server.html
+pub(crate) fn remap_relative_uri(msg: &mut Message, cwd: &Url) -> Result<(), std::io::Error> {
+    match msg {
+        Message::Notification(notification) => match notification {
+            Notification::DidSave { params } => {
+                remap_text_document_identifier(&mut params.text_document, cwd)?;
+            }
+
+            Notification::DidChangeWorkspaceFolders { params } => {
+                for folder in &mut params.event.added {
+                    remap_workspace_folder(folder, cwd)?;
+                }
+                for folder in &mut params.event.removed {
+                    remap_workspace_folder(folder, cwd)?;
+                }
+            }
+
+            Notification::DidChangeWatchedFiles { params } => {
+                for event in &mut params.changes {
+                    if let Some(uri) = to_file(&event.uri, cwd)? {
+                        event.uri = uri;
+                    }
+                }
+            }
+
+            Notification::DidOpen { params } => {
+                if let Some(uri) = to_file(&params.text_document.uri, cwd)? {
+                    params.text_document.uri = uri;
+                }
+            }
+
+            Notification::DidChange { params } => {
+                if let Some(uri) = to_file(&params.text_document.uri, cwd)? {
+                    params.text_document.uri = uri;
+                }
+            }
+
+            Notification::WillSave { params } => {
+                remap_text_document_identifier(&mut params.text_document, cwd)?;
+            }
+
+            Notification::DidClose { params } => {
+                remap_text_document_identifier(&mut params.text_document, cwd)?;
+            }
+
+            Notification::PublishDiagnostics { params } => {
+                // `to_source` because this goes to client
+                if let Some(uri) = to_source(&params.uri, cwd)? {
+                    params.uri = uri;
+                }
+            }
+
+            Notification::DidChangeConfiguration { params: _ }
+            | Notification::Initialized { params: _ }
+            | Notification::Exit { params: _ }
+            | Notification::LogMessage { params: _ }
+            | Notification::ShowMessage { params: _ }
+            | Notification::Progress { params: _ }
+            | Notification::CancelRequest { params: _ }
+            | Notification::TelemetryEvent { params: _ } => {}
+        },
+
+        Message::Request(request) => match request {
+            Request::Initialize { id: _, params: p } => {
+                if let Some(root_uri) = &p.root_uri {
+                    if let Some(uri) = to_file(root_uri, cwd)? {
+                        p.root_uri = Some(uri);
+                    }
+                }
+                if let Some(folders) = &mut p.workspace_folders {
+                    for folder in folders {
+                        remap_workspace_folder(folder, cwd)?;
+                    }
+                }
+            }
+
+            Request::DocumentSymbol { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::WillSaveWaitUntil { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::Completion { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document_position.text_document, cwd)?;
+            }
+
+            Request::Hover { id: _, params: p } => {
+                remap_text_document_identifier(
+                    &mut p.text_document_position_params.text_document,
+                    cwd,
+                )?;
+            }
+
+            Request::SignatureHelp { id: _, params: p } => {
+                remap_text_document_identifier(
+                    &mut p.text_document_position_params.text_document,
+                    cwd,
+                )?;
+            }
+
+            Request::GotoDeclaration { id: _, params: p }
+            | Request::GotoDefinition { id: _, params: p }
+            | Request::GotoTypeDefinition { id: _, params: p }
+            | Request::GotoImplementation { id: _, params: p } => {
+                remap_text_document_identifier(
+                    &mut p.text_document_position_params.text_document,
+                    cwd,
+                )?;
+            }
+
+            Request::References { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document_position.text_document, cwd)?;
+            }
+
+            Request::DocumentHighlight { id: _, params: p } => {
+                remap_text_document_identifier(
+                    &mut p.text_document_position_params.text_document,
+                    cwd,
+                )?;
+            }
+
+            Request::CodeAction { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::CodeLens { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::DocumentLink { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::DocumentLinkResolve { id: _, params: p } => {
+                if let Some(target) = &p.target {
+                    if let Some(uri) = to_file(target, cwd)? {
+                        p.target = Some(uri);
+                    }
+                }
+            }
+
+            Request::DocumentColor { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::ColorPresentation { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::Formatting { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::RangeFormatting { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::OnTypeFormatting { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document_position.text_document, cwd)?;
+            }
+
+            Request::Rename { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document_position.text_document, cwd)?;
+            }
+
+            Request::PrepareRename { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::FoldingRange { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            Request::SelectionRange { id: _, params: p } => {
+                remap_text_document_identifier(&mut p.text_document, cwd)?;
+            }
+
+            // To Client
+            Request::ApplyEdit { id: _, params: p } => {
+                remap_workspace_edit(&mut p.edit, cwd)?;
+            }
+
+            // To Client
+            Request::Configuration { id: _, params: _ } => {
+                // REVIEW lsp_types has Option<String> for `scope_uri` while the spec has `DocumentUri`.
+                // https://github.com/gluon-lang/lsp-types/pull/180
+                // for item in &mut p.items {
+                //     if let Some(uri) = &item.scope_uri {}
+                // }
+            }
+
+            Request::WorkspaceFolders { id: _, params: _ }
+            | Request::ShowMessage { id: _, params: _ }
+            | Request::CompletionResolve { id: _, params: _ }
+            | Request::CodeLensResolve { id: _, params: _ }
+            | Request::RegisterCapability { id: _, params: _ }
+            | Request::UnregisterCapability { id: _, params: _ }
+            | Request::CreateWorkDoneProgress { id: _, params: _ }
+            | Request::CancelWorkDoneProgress { id: _, params: _ }
+            | Request::Symbol { id: _, params: _ }
+            | Request::ExecuteCommand { id: _, params: _ }
+            | Request::Shutdown { id: _, params: _ } => {}
+        },
+
+        Message::Response(response) => match response {
+            Response::Success { id: _, result } => {
+                match result {
+                    ResponseResult::DocumentLinkWithTarget(links) => {
+                        for link in links {
+                            if let Some(uri) = to_source(&link.target, cwd)? {
+                                link.target = uri;
+                            }
+                        }
+                    }
+
+                    ResponseResult::DocumentLinkWithTargetResolve(link) => {
+                        if let Some(uri) = to_source(&link.target, cwd)? {
+                            link.target = uri;
+                        }
+                    }
+
+                    ResponseResult::CodeAction(actions) => {
+                        for aoc in actions {
+                            match aoc {
+                                lsp_types::CodeActionOrCommand::Command(_) => {}
+                                lsp_types::CodeActionOrCommand::CodeAction(action) => {
+                                    if let Some(workspace_edit) = &mut action.edit {
+                                        remap_workspace_edit(workspace_edit, cwd)?;
+                                    }
+                                }
+                            }
+                        }
+                    }
+
+                    ResponseResult::Location(location) => {
+                        remap_location(location, cwd)?;
+                    }
+
+                    ResponseResult::Locations(locations) => {
+                        for location in locations {
+                            remap_location(location, cwd)?;
+                        }
+                    }
+
+                    ResponseResult::LocationLinks(links) => {
+                        for link in links {
+                            if let Some(uri) = to_source(&link.target_uri, cwd)? {
+                                link.target_uri = uri;
+                            }
+                        }
+                    }
+
+                    ResponseResult::SymbolInfos(syms) => {
+                        for sym in syms {
+                            remap_location(&mut sym.location, cwd)?;
+                        }
+                    }
+
+                    ResponseResult::WorkspaceFolders(folders) => {
+                        for folder in folders {
+                            // `to_file` because this is a response from Client.
+                            if let Some(uri) = to_file(&folder.uri, cwd)? {
+                                folder.uri = uri;
+                            }
+                        }
+                    }
+
+                    ResponseResult::WorkspaceEditWithBoth(edit) => {
+                        remap_workspace_edit_changes(&mut edit.changes, cwd)?;
+                        remap_document_changes(&mut edit.document_changes, cwd)?;
+                    }
+
+                    ResponseResult::WorkspaceEditWithChanges(edit) => {
+                        remap_workspace_edit_changes(&mut edit.changes, cwd)?;
+                    }
+
+                    ResponseResult::WorkspaceEditWithDocumentChanges(edit) => {
+                        remap_document_changes(&mut edit.document_changes, cwd)?;
+                    }
+
+                    ResponseResult::Any(_) => {}
+                }
+            }
+
+            Response::Failure { id: _, error: _ } => {}
+        },
+
+        Message::Unknown(_) => {}
+    }
+    Ok(())
+}
+
+fn to_file(uri: &Url, cwd: &Url) -> Result<Option<Url>, std::io::Error> {
+    if uri.scheme() == "source" {
+        cwd.join(uri.as_str().strip_prefix("source://").unwrap())
+            .map_err(map_parse_error)
+            .map(Some)
+    } else {
+        Ok(None)
+    }
+}
+
+fn to_source(uri: &Url, cwd: &Url) -> Result<Option<Url>, std::io::Error> {
+    if uri.scheme() == "file" {
+        if let Some(rel) = uri.as_str().strip_prefix(cwd.as_str()) {
+            let source_uri = format!("source://{}", rel);
+            Url::parse(&source_uri).map_err(map_parse_error).map(Some)
+        } else {
+            Ok(None)
+        }
+    } else {
+        Ok(None)
+    }
+}
+
+fn map_parse_error(err: url::ParseError) -> std::io::Error {
+    std::io::Error::new(std::io::ErrorKind::InvalidData, err)
+}
+
+/// Remap `DocumentUri` in `WorkspaceEdit` to use `source://`
+fn remap_workspace_edit(
+    workspace_edit: &mut lsp_types::WorkspaceEdit,
+    cwd: &Url,
+) -> Result<(), std::io::Error> {
+    if let Some(changes) = &mut workspace_edit.changes {
+        remap_workspace_edit_changes(changes, cwd)?;
+    }
+
+    if let Some(doc_changes) = &mut workspace_edit.document_changes {
+        remap_document_changes(doc_changes, cwd)?;
+    }
+    Ok(())
+}
+
+/// Remap keys of `WorkspaceEdit.changes`
+fn remap_workspace_edit_changes(
+    changes: &mut HashMap<Url, Vec<lsp_types::TextEdit>>,
+    cwd: &Url,
+) -> Result<(), std::io::Error> {
+    let mut tmp = Vec::with_capacity(changes.len());
+    for (key, val) in changes.drain() {
+        if let Some(rel) = to_source(&key, cwd)? {
+            tmp.push((rel, val));
+        } else {
+            tmp.push((key, val));
+        }
+    }
+    for (key, val) in tmp {
+        changes.insert(key, val);
+    }
+    Ok(())
+}
+
+fn remap_document_changes(
+    document_changes: &mut lsp_types::DocumentChanges,
+    cwd: &Url,
+) -> Result<(), std::io::Error> {
+    match document_changes {
+        lsp_types::DocumentChanges::Edits(edits) => {
+            for edit in edits {
+                if let Some(uri) = to_source(&edit.text_document.uri, cwd)? {
+                    edit.text_document.uri = uri;
+                }
+            }
+        }
+
+        lsp_types::DocumentChanges::Operations(ops) => {
+            for op in ops {
+                match op {
+                    lsp_types::DocumentChangeOperation::Op(op) => match op {
+                        lsp_types::ResourceOp::Create(c) => {
+                            if let Some(uri) = to_source(&c.uri, cwd)? {
+                                c.uri = uri;
+                            }
+                        }
+                        lsp_types::ResourceOp::Rename(r) => {
+                            if let Some(u) = to_source(&r.old_uri, cwd)? {
+                                r.old_uri = u;
+                            }
+                            if let Some(u) = to_source(&r.new_uri, cwd)? {
+                                r.new_uri = u;
+                            }
+                        }
+                        lsp_types::ResourceOp::Delete(d) => {
+                            if let Some(u) = to_source(&d.uri, cwd)? {
+                                d.uri = u;
+                            }
+                        }
+                    },
+
+                    lsp_types::DocumentChangeOperation::Edit(e) => {
+                        if let Some(u) = to_source(&e.text_document.uri, cwd)? {
+                            e.text_document.uri = u;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Remap `Location.uri` to use `source://`
+fn remap_location(location: &mut lsp_types::Location, cwd: &Url) -> Result<(), std::io::Error> {
+    if let Some(uri) = to_source(&location.uri, cwd)? {
+        location.uri = uri;
+    }
+    Ok(())
+}
+
+/// Remap `TextDocumentIdentifier.uri` to use `file://`
+fn remap_text_document_identifier(
+    text_document: &mut lsp_types::TextDocumentIdentifier,
+    cwd: &Url,
+) -> Result<(), std::io::Error> {
+    if let Some(uri) = to_file(&text_document.uri, cwd)? {
+        text_document.uri = uri;
+    }
+    Ok(())
+}
+
+fn remap_workspace_folder(
+    folder: &mut lsp_types::WorkspaceFolder,
+    cwd: &Url,
+) -> Result<(), std::io::Error> {
+    if let Some(uri) = to_file(&folder.uri, cwd)? {
+        folder.uri = uri;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::Path;
+    use url::Url;
+
+    #[test]
+    fn test_to_file() {
+        let cwd = Url::from_directory_path(Path::new("/workspace")).unwrap();
+        let uri = Url::parse("source://src/main.rs").unwrap();
+        let remapped = to_file(&uri, &cwd).unwrap().unwrap();
+        assert_eq!(remapped.as_str(), "file:///workspace/src/main.rs");
+    }
+
+    #[test]
+    fn test_to_source() {
+        let cwd = Url::from_directory_path(Path::new("/workspace")).unwrap();
+        let uri = Url::from_file_path(Path::new("/workspace/src/main.rs")).unwrap();
+        let remapped = to_source(&uri, &cwd).unwrap().unwrap();
+        assert_eq!(remapped.as_str(), "source://src/main.rs");
+    }
+}

--- a/src/lsp/ext/relative_uri.rs
+++ b/src/lsp/ext/relative_uri.rs
@@ -192,12 +192,14 @@ pub(crate) fn remap_relative_uri(msg: &mut Message, cwd: &Url) -> Result<(), std
             }
 
             // To Client
-            Request::Configuration { id: _, params: _ } => {
-                // REVIEW lsp_types has Option<String> for `scope_uri` while the spec has `DocumentUri`.
-                // https://github.com/gluon-lang/lsp-types/pull/180
-                // for item in &mut p.items {
-                //     if let Some(uri) = &item.scope_uri {}
-                // }
+            Request::Configuration { id: _, params: p } => {
+                for item in &mut p.items {
+                    if let Some(scope_uri) = &item.scope_uri {
+                        if let Some(uri) = to_source(scope_uri, cwd)? {
+                            item.scope_uri = Some(uri);
+                        }
+                    }
+                }
             }
 
             Request::WorkspaceFolders { id: _, params: _ }

--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -1,10 +1,10 @@
 pub(crate) mod error;
+pub(crate) mod ext;
 pub(crate) mod framed;
 mod notification;
 mod request;
 mod response;
 pub(crate) mod types;
-// TODO Typed Result
 
 use std::{convert::TryFrom, str::FromStr};
 
@@ -13,7 +13,7 @@ use serde::{Deserialize, Serialize};
 
 pub(crate) use notification::Notification;
 pub(crate) use request::Request;
-pub(crate) use response::Response;
+pub(crate) use response::{Response, ResponseResult};
 use types::Unknown;
 
 #[derive(Clone, Debug, PartialEq, Deserialize)]

--- a/src/lsp/notification.rs
+++ b/src/lsp/notification.rs
@@ -3,19 +3,6 @@ use serde::{Deserialize, Serialize};
 // NOTE Not using `lsp_types::lsp_notification!` because rust-analyzer
 // doesn't seem to understand it well at the moment and shows `{unknown}`.
 
-// TODO Remove this when a new version of `lsp_types` is published with the fix.
-// https://github.com/gluon-lang/lsp-types/pull/178
-#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
-#[serde(rename_all = "camelCase")]
-pub(crate) struct DidSaveTextDocumentParams {
-    /// The document that was saved.
-    pub text_document: lsp_types::TextDocumentIdentifier,
-    /// Optional the content when saved. Depends on the includeText value
-    /// when the save notification was requested.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub text: Option<String>,
-}
-
 /// A [notification message].
 ///
 /// [notification message]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#notificationMessage
@@ -79,7 +66,9 @@ pub(crate) enum Notification {
     // To Server
     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didSave
     #[serde(rename = "textDocument/didSave")]
-    DidSave { params: DidSaveTextDocumentParams },
+    DidSave {
+        params: lsp_types::DidSaveTextDocumentParams,
+    },
 
     // To Server
     // https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_didClose

--- a/src/lsp/response.rs
+++ b/src/lsp/response.rs
@@ -1,15 +1,189 @@
+use std::collections::HashMap;
+
 use serde::{Deserialize, Serialize};
 
 use super::error::Error;
 use super::types::Id;
 
-/// Untyped [response message]. Either Success or Failure response.
+/// [Response message]. Either Success or Failure response.
 ///
-/// [response message]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
+/// [Response message]: https://microsoft.github.io/language-server-protocol/specifications/specification-current/#responseMessage
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 #[serde(untagged)]
 pub(crate) enum Response {
-    Success { id: Id, result: serde_json::Value },
+    Success { id: Id, result: ResponseResult },
 
     Failure { id: Option<Id>, error: Error },
+}
+
+// Typed results so we can remap relative URI.
+// Note that the order is significant because it's deserialized to the first variant that works.
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+#[serde(untagged)]
+#[serde(deny_unknown_fields)]
+pub(crate) enum ResponseResult {
+    // remap location
+    // {name,kind,location, tags?,deprecated?,containerName?}[]
+    SymbolInfos(Vec<lsp_types::SymbolInformation>),
+    // remap targetUri
+    // {targetUri,targetRange,targetSelectionRange,originSelectionRange?}[]
+    LocationLinks(Vec<lsp_types::LocationLink>),
+    // remap uri
+    // {uri,range}[]
+    Locations(Vec<lsp_types::Location>),
+    // remap uri
+    // {uri,range}
+    Location(lsp_types::Location),
+    // remap uri
+    // {uri,name}[]
+    WorkspaceFolders(Vec<lsp_types::WorkspaceFolder>),
+    // remap target
+    // {range,target, tooltip?,data?}[]
+    DocumentLinkWithTarget(Vec<DocumentLinkWithTarget>),
+    // remap target
+    // {range,target, tooltip?,data?}
+    DocumentLinkWithTargetResolve(DocumentLinkWithTarget),
+    // remap if action.edit is present
+    // ({title,command, arguments?} | {title, kind?,diagnostics?,edit?,command?,isPreferred?})[]
+    CodeAction(lsp_types::CodeActionResponse),
+    // remap changes and documentChanges
+    // {changes, documentChanges}
+    WorkspaceEditWithBoth(WorkspaceEditWithBoth),
+    // remap changes
+    // {changes}
+    WorkspaceEditWithChanges(WorkspaceEditWithChanges),
+    // remap documentChanges
+    // {documentChanges}
+    WorkspaceEditWithDocumentChanges(WorkspaceEditWithDocumentChanges),
+
+    // noremap
+    // {name,kind,range,selectionRange, detail?,tags?,deprecated?,children?}[]
+    // DocumentSymbols(Vec<lsp_types::DocumentSymbol>),
+
+    // noremap
+    // {capabilities: {}, serverInfo?: {}}
+    // Initialize(lsp_types::InitializeResult),
+
+    // noremap
+    // {contents, range?}
+    // Hover(lsp_types::Hover),
+
+    // noremap
+    // {signatures, activeSignature?,activeParameter?}
+    // SignatureHelp(lsp_types::SignatureHelp),
+
+    // noremap
+    // {range,newText}[]
+    // Formatting(Vec<lsp_types::TextEdit>),
+
+    // noremap
+    // {range,color}[]
+    // DocumentColor(Vec<lsp_types::ColorInformation>),
+
+    // noremap
+    //   {label, kind?,detail?,documentation?,deprecated?,preselect?,sortText?,
+    //           filterText?,insertText?,insertTextFormat?,tetEdit?,additionalTextEdits?,
+    //           command?,data?,tags?}[]
+    // | {isComplete, items}
+    // Must be before `ColorPresentation`
+    // Completion(lsp_types::CompletionResponse),
+
+    // noremap
+    // {label,textEdit?,additionalTextEdits?}[]
+    // ColorPresentation(Vec<lsp_types::ColorPresentation>),
+
+    // noremap
+    // {applied}
+    // ApplyWorkspaceEdit(lsp_types::ApplyWorkspaceEditResponse),
+
+    // noremap
+    // {label, kind?,detail?,documentation?,deprecated?,preselect?,sortText?,
+    //         filterText?,insertText?,insertTextFormat?,tetEdit?,additionalTextEdits?,
+    //         command?,data?,tags?}[]
+    // ResolveCompletionItem(lsp_types::CompletionItem),
+
+    // noremap
+    // {title}
+    // ShowMessage(lsp_types::MessageActionItem),
+
+    // noremap
+    // {start, end} | {range, placeholder}
+    // PrepareRename(lsp_types::PrepareRenameResponse),
+
+    // noremap
+    // {startLine,endLine, startCharacter?,endCharacter?,kind?}
+    // FoldingRange(Vec<lsp_types::FoldingRange>),
+
+    // noremap
+    // {range, command?,data?}[]
+    // CodeLens(Vec<lsp_types::CodeLens>),
+
+    // noremap
+    // {range, parent?}[]
+    // SelectionRange(Vec<lsp_types::SelectionRange>),
+
+    // noremap
+    // {range, kind?}[]
+    // DocumentHighlight(Vec<lsp_types::DocumentHighlight>),
+
+    // noremap
+    // {range, command?,data?}
+    // CodeLensResolve(lsp_types::CodeLens),
+
+    // noremap
+    Any(serde_json::Value),
+    // Proposed
+    //   SemanticTokensFull(lsp_types::SemanticTokensResult),
+    //   SemanticTokensFullDelta(lsp_types::SemanticTokensFullDeltaResult),
+    //   SemanticTokensRange(lsp_types::SemanticTokensRangeResult),
+    //
+    //   CallHierarchyPrepare(Vec<lsp_types::CallHierarchyItem>),
+    //   CallHierarchyOutgoingCalls(Vec<lsp_types::CallHierarchyOutgoingCall>),
+    //   CallHierarchyIncomingCalls(Vec<lsp_types::CallHierarchyIncomingCall>),
+}
+
+// Some custom types to make untagged enum work.
+//
+// `DocumentLink` (`{range, target?,tooltip?,data?}`) needs to be remapped when `target` is present.
+// But using it in untagged enum will deserialize any objects with `range` as `DocumentLink`.
+// We define `DocumentLinkWithTarget` (`{range,target, tooltip?,data?}`) to workaround this.
+//
+// `lsp_types::DocumentLink` with `target` set.
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+pub(crate) struct DocumentLinkWithTarget {
+    pub(crate) range: lsp_types::Range,
+    pub(crate) target: url::Url,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) tooltip: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) data: Option<serde_json::Value>,
+}
+
+// `WorkspaceEdit` (`{changes?, documentChanges?}`) needs to be remapped. But we can't
+// match it using untagged enum because both fields are optional making it match any objects.
+// We define the following custom types to workaround it.
+// - With both: `{changes, documentChanges}`
+// - With `changes`: `{changes}`
+// - With `documentChanges`: `{documentChanges}`
+//
+// `lsp_types::WorkspaceEdit` both `changes` and `document_changes`
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceEditWithBoth {
+    pub(crate) changes: HashMap<url::Url, Vec<lsp_types::TextEdit>>,
+    pub(crate) document_changes: lsp_types::DocumentChanges,
+}
+
+// `lsp_types::WorkspaceEdit` with `changes`
+#[derive(Debug, Eq, PartialEq, Clone, Default, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceEditWithChanges {
+    pub(crate) changes: HashMap<url::Url, Vec<lsp_types::TextEdit>>,
+}
+
+// `lsp_types::WorkspaceEdit` with `document_changes`
+#[derive(Debug, Eq, PartialEq, Clone, Deserialize, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct WorkspaceEditWithDocumentChanges {
+    pub(crate) document_changes: lsp_types::DocumentChanges,
 }


### PR DESCRIPTION
Clients can use `source://` to specify the location of a file relative to the current directory. So they no longer need to know the exact location of the project root on the remote machine to use the service.


`source://` was chosen because it's used by [Metals Remote Language Server].

[Metals Remote Language Server]: scalameta.org/metals/docs/contributors/remote-language-server.html