### PR TITLE
Change the default address to 0.0.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Examples:
   lsp-ws-proxy -l 8888 -- langserver --stdio
 
 Options:
-  -l, --listen      address or localhost's port to listen on (default: 9999)
+  -l, --listen      address or port to listen on (default: 0.0.0.0:9999)
   -t, --timeout     inactivity timeout in seconds
   -s, --sync        write text document to disk on save
   -r, --remap       remap relative uri (source://)

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,11 +32,11 @@ Examples:
   lsp-ws-proxy -l 8888 -- langserver --stdio
 */
 struct Options {
-    /// address or localhost's port to listen on (default: 9999)
+    /// address or port to listen on (default: 0.0.0.0:9999)
     #[argh(
         option,
         short = 'l',
-        default = "String::from(\"127.0.0.1:9999\")",
+        default = "String::from(\"0.0.0.0:9999\")",
         from_str_fn(parse_listen)
     )]
     listen: String,
@@ -149,9 +149,9 @@ async fn maybe_write_text_document(msg: &lsp::Message) -> Result<(), std::io::Er
 }
 
 fn parse_listen(value: &str) -> Result<String, String> {
-    // If a number is given, treat it as a localhost's port number
+    // Allow specifying only a port number.
     if value.chars().all(|c| c.is_ascii_digit()) {
-        return Ok(format!("127.0.0.1:{}", value));
+        return Ok(format!("0.0.0.0:{}", value));
     }
 
     match value.parse::<SocketAddr>() {


### PR DESCRIPTION
Using 127.0.0.1 inside a container makes it unreachable from the host
because it binds to the container's `lo` interface.