### PR TITLE
Fix serializing unknown notification

### DIFF
--- a/src/lsp/mod.rs
+++ b/src/lsp/mod.rs
@@ -107,13 +107,7 @@ impl Serialize for Message {
                 wrapped.serialize(serializer)
             }
 
-            Self::Unknown(unknown) => {
-                let wrapped = WithJsonRpc {
-                    jsonrpc: "2.0",
-                    msg: &unknown,
-                };
-                wrapped.serialize(serializer)
-            }
+            Self::Unknown(unknown) => unknown.serialize(serializer),
         }
     }
 }
@@ -154,5 +148,13 @@ mod tests {
         let from_str: Message = serde_json::from_str(&v.to_string()).unwrap();
         let from_value: Message = serde_json::from_value(v).unwrap();
         assert_eq!(from_str, from_value);
+    }
+
+    #[test]
+    fn test_serialize_unknown_notification() {
+        let v = json!({"jsonrpc":"2.0","method":"language/status","params":{"message":""}});
+        let s = v.to_string();
+        let from_value: Message = serde_json::from_value(v).unwrap();
+        assert_eq!(serde_json::to_string(&from_value).unwrap(), s);
     }
 }

--- a/src/lsp/types.rs
+++ b/src/lsp/types.rs
@@ -32,11 +32,4 @@ pub enum Params {
 
 /// Unknown message type.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
-pub struct Unknown {
-    #[serde(default)]
-    pub id: Option<Id>,
-    #[serde(default)]
-    pub method: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub params: Option<Params>,
-}
+pub struct Unknown(serde_json::Value);


### PR DESCRIPTION
`"id": null` was added when serialized because of defaulting.
This causes invalid message error on client.

Use `serde_json::Value` to keep them as is.